### PR TITLE
Get events route

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::EventsController < ApplicationController
+  def index
+    render json: EventSerializer.new(Sport.includes(:events))
+  end
+end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,0 +1,10 @@
+class EventSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :sport
+  
+  attributes :name
+
+  attributes :events do |obj|
+    obj.events.pluck(:name)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/olympians', to: 'olympians#index'
       get '/olympian_stats', to: 'olympian_stats#index'
+      get '/events', to: 'events#index'
     end
   end
 end

--- a/spec/requests/api/v1/get_all_events_request_spec.rb
+++ b/spec/requests/api/v1/get_all_events_request_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'Olympians API' do
+  describe 'GET all events request' do
+    before(:each) do
+      @taekwondo = Sport.create!(name: "Tae Kwon Do")
+      @boxing = Sport.create!(name: "Boxing")
+      @mens_tkd = Event.create!(name: "Men's Tae Kwon Do", sport: @taekwondo)
+      @womens_tkd = Event.create!(name: "Women's Tae Kwon Do", sport: @taekwondo)
+      @mens_boxing = Event.create!(name: "Men's Boxing", sport: @boxing)
+      @womens_boxing = Event.create!(name: "Women's Boxing", sport: @boxing)
+    end
+
+    it "returns a list of all events" do
+      get '/api/v1/events'
+
+      expect(response).to be_successful
+
+      events = JSON.parse(response.body)
+
+      expect(events["data"].count).to eq(2)
+      expect(events["data"][0]).to have_key("id")
+      expect(events["data"][0]).to have_key("type")
+      expect(events["data"][0]["attributes"]).to have_key("name")
+      expect(events["data"][0]["attributes"]).to have_key("events")
+      expect(events["data"][0]["attributes"]["events"].count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
- Able to send GET request to `/api/v1/events` to receive a list of all events grouped by its sport
- Closes #5 